### PR TITLE
adding method to accept date as string and attempt to convert to DateTime

### DIFF
--- a/src/Exceptions/InvalidFormatException.php
+++ b/src/Exceptions/InvalidFormatException.php
@@ -1,0 +1,6 @@
+<?php namespace JobBrander\Jobs\Client\Exceptions;
+
+class InvalidFormatException extends \Exception
+{
+
+}

--- a/src/Job.php
+++ b/src/Job.php
@@ -149,7 +149,7 @@ class Job extends JobPosting
      */
     public function setDatePostedAsString($datePosted)
     {
-        if (strtotime($datePosted) !== FALSE) {
+        if (strtotime($datePosted) !== false) {
             $datePosted = new DateTime($datePosted);
 
             $this->setDatePosted($datePosted);

--- a/src/Job.php
+++ b/src/Job.php
@@ -1,5 +1,7 @@
 <?php namespace JobBrander\Jobs\Client;
 
+use \DateTime;
+use JobBrander\Jobs\Client\Exceptions\InvalidFormatException;
 use JobBrander\Jobs\Client\Schema\Entity\JobPosting;
 use JobBrander\Jobs\Client\Schema\Entity\Organization;
 use JobBrander\Jobs\Client\Schema\Entity\Place;
@@ -136,6 +138,26 @@ class Job extends JobPosting
         array_walk($attributes, function ($value, $key) {
             $this->{$key} = $value;
         });
+    }
+
+    /**
+     * Sets datePosted.
+     *
+     * @param string $datePosted
+     *
+     * @return $this
+     */
+    public function setDatePostedAsString($datePosted)
+    {
+        if (strtotime($datePosted) !== FALSE) {
+            $datePosted = new DateTime($datePosted);
+
+            $this->setDatePosted($datePosted);
+        } else {
+            throw new InvalidFormatException;
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Schema/Entity/JobPosting.php
+++ b/src/Schema/Entity/JobPosting.php
@@ -141,7 +141,7 @@ class JobPosting extends Thing
     /**
      * Sets datePosted.
      *
-     * @param \DateTime $datePosted
+     * @param mixed $datePosted
      *
      * @return $this
      */

--- a/test/src/JobTest.php
+++ b/test/src/JobTest.php
@@ -325,11 +325,26 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($url, $this->job->getCompanyUrl());
     }
 
-    public function testSetDatePosted()
+    public function testSetDatePostedWithValidDateTime()
     {
         $date = new \DateTime;
         $this->job->setDatePosted($date);
         $this->assertEquals($date, $this->job->getDatePosted());
+    }
+
+    public function testSetDatePostedAsStringWithValidDateTimeString()
+    {
+        $date = '2015-05-01';
+        $this->job->setDatePostedAsString($date);
+    }
+
+    /**
+     * @expectedException JobBrander\Jobs\Client\Exceptions\InvalidFormatException
+     */
+    public function testSetDatePostedAsStringWithoutValidDateTimeString()
+    {
+        $date = 'i like turtles';
+        $this->job->setDatePostedAsString($date);
     }
 
     public function testBenignTextValues()


### PR DESCRIPTION
Related to the concerns in #6 I added a helper method that offers a bit of assistance to provider implementations to attempt to parse a string as valid DateTime before setting the value using the parent method. 

If the provider implementations wish to coerce the data before setting, they are welcome to use the stock method directly; this should be encouraged. Otherwise this method can be used if folks are feeling lazy. 

If the method does not determine that the item provided is a valid date it will throw a new exception, specific to this project. 

cc: @karllhughes 