### PR TITLE
Currency format

### DIFF
--- a/src/Job.php
+++ b/src/Job.php
@@ -139,6 +139,24 @@ class Job extends JobPosting
     }
 
     /**
+     * Sets baseSalary.
+     *
+     * @param float $baseSalary
+     *
+     * @return $this
+     */
+    public function setBaseSalary($baseSalary)
+    {
+        $baseSalary = $this->convertCurrency($baseSalary);
+
+        if ($baseSalary) {
+            parent::setBaseSalary($baseSalary);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get street address
      *
      * @return string
@@ -692,5 +710,17 @@ class Job extends JobPosting
         $this->setJobLocation($location);
 
         return $this;
+    }
+
+    /**
+     * Attempt to convert currency to float
+     *
+     * @param  mixed $amount
+     *
+     * @return float|null
+     */
+    private function convertCurrency($amount)
+    {
+        return null;
     }
 }

--- a/src/Job.php
+++ b/src/Job.php
@@ -721,6 +721,12 @@ class Job extends JobPosting
      */
     private function convertCurrency($amount)
     {
+        $amount = preg_replace('/[^\\d.]+/', '', $amount);
+
+        if (is_numeric($amount)) {
+            return (float) $amount;
+        }
+
         return null;
     }
 }

--- a/test/src/JobTest.php
+++ b/test/src/JobTest.php
@@ -191,6 +191,50 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result, $this->job->getBaseSalary());
     }
 
+    public function testSetBaseSalaryWithOnlyNumbersAndDecimal()
+    {
+        $input = '100000.00';
+        $result = 100000.00;
+        $this->job->setBaseSalary($input);
+        $this->assertEquals($result, $this->job->baseSalary);
+        $this->assertEquals($result, $this->job->getBaseSalary());
+    }
+
+    public function testSetBaseSalaryWithOnlyNumbersAndMisplacedDecimal()
+    {
+        $input = '100.00000';
+        $result = 100.00;
+        $this->job->setBaseSalary($input);
+        $this->assertEquals($result, $this->job->baseSalary);
+        $this->assertEquals($result, $this->job->getBaseSalary());
+    }
+
+    public function testSetBaseSalaryWithCommas()
+    {
+        $input = '100,000';
+        $result = 100000.00;
+        $this->job->setBaseSalary($input);
+        $this->assertEquals($result, $this->job->baseSalary);
+        $this->assertEquals($result, $this->job->getBaseSalary());
+    }
+
+    public function testSetBaseSalaryWithCurrencySymbol()
+    {
+        $input = '$100000';
+        $result = 100000.00;
+        $this->job->setBaseSalary($input);
+        $this->assertEquals($result, $this->job->baseSalary);
+        $this->assertEquals($result, $this->job->getBaseSalary());
+    }
+
+    public function testSetBaseSalaryWithoutNumbers()
+    {
+        $input = 'i like turtles.';
+        $this->job->setBaseSalary($input);
+        $this->assertNull($this->job->baseSalary);
+        $this->assertNull($this->job->getBaseSalary());
+    }
+
     public function testSetCompany()
     {
         $company = uniqid();

--- a/test/src/JobTest.php
+++ b/test/src/JobTest.php
@@ -182,6 +182,15 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($input, $this->job->getMaximumSalary());
     }
 
+    public function testSetBaseSalaryWithOnlyNumbers()
+    {
+        $input = '100000';
+        $result = 100000.00;
+        $this->job->setBaseSalary($input);
+        $this->assertEquals($result, $this->job->baseSalary);
+        $this->assertEquals($result, $this->job->getBaseSalary());
+    }
+
     public function testSetCompany()
     {
         $company = uniqid();


### PR DESCRIPTION
Related to #9 I've added some support to `setBaseSalary` that will attempt to convert the value to a float before setting it on the parent class. This will ensure that the base object is still schema.org compliant. 

If the value is not numeric or cannot be coerced into float, the baseSalary property will not be set.

cc: @karllhughes 