### PR TITLE
Job object codes removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All Notable changes to `jobs-common` will be documented in this file
 ## 0.4.1 - 2015-05-14
 
 ### Added
+- setOccupationalCategory method to help add standardized code/category as
+specified by schema.org Job Posting
+-
+
+### Deprecated
+- "codes" attribute removed
+
+### Fixed
+- Nothing
+
+### Removed
+- Nothing
+
+### Security
+- Nothing
+
+## 0.4.1 - 2015-05-14
+
+### Added
 - Helper function to set date from string
 - Convert strings in base salary to currency format
 
@@ -70,7 +89,7 @@ All Notable changes to `jobs-common` will be documented in this file
 ### Deprecated
 - Job Companies
 - Job Industries
-- Job Locations 
+- Job Locations
 - Job Dates
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,18 @@
 # Changelog
 All Notable changes to `jobs-common` will be documented in this file
 
-## 0.4.1 - 2015-05-14
+## 0.5.0 - 2015-05-15
 
 ### Added
 - setOccupationalCategory method to help add standardized code/category as
 specified by schema.org Job Posting
--
+- Attributes javascriptAction and javascriptFunction replace codes
+array attribute
 
 ### Deprecated
 - "codes" attribute removed
+- AddToArray in trait (no more arrays exist in job attributes)
+- IsAdderMethod because no more adders
 
 ### Fixed
 - Nothing

--- a/src/AttributeTrait.php
+++ b/src/AttributeTrait.php
@@ -76,31 +76,9 @@ trait AttributeTrait
             return $this;
         } elseif ($this->isGetterMethod($method)) {
             return $this->{$attribute};
-        } elseif ($this->isAdderMethod($method)) {
-            return $this->addToArrayProperty($attribute, $value);
         }
 
         throw new \BadMethodCallException;
-    }
-
-    /**
-     * Add a value to a given array property. If property is not array,
-     * transform into array.
-     *
-     * @param  string $attribute
-     * @param  mixed  $value
-     *
-     * @return mixed
-     */
-    private function addToArrayProperty($attribute, $value)
-    {
-        if (property_exists($this, $attribute)) {
-            if (is_array($this->$attribute)) {
-                array_push($this->$attribute, $value);
-            }
-        }
-
-        return $this;
     }
 
     /**
@@ -113,18 +91,6 @@ trait AttributeTrait
     private function getAttributeFromGetSetMethod($method)
     {
         return lcfirst(preg_replace('/[s|g]et|add/', '', $method));
-    }
-
-    /**
-     * Checks if given method name is an add method
-     *
-     * @param  string $method
-     *
-     * @return boolean
-     */
-    private function isAdderMethod($method)
-    {
-        return substr($method, 0, 3) === "add";
     }
 
     /**

--- a/src/Job.php
+++ b/src/Job.php
@@ -8,7 +8,7 @@ use JobBrander\Jobs\Client\Schema\Entity\Place;
 use JobBrander\Jobs\Client\Schema\Entity\PostalAddress;
 
 /**
- * @method Job getId()
+ * @method Job getSourceId()
  * @method Job getTitle()
  * @method Job getDescription()
  * @method Job getSource()
@@ -22,7 +22,7 @@ use JobBrander\Jobs\Client\Schema\Entity\PostalAddress;
  * @method Job getEndDate()
  * @method Job getMinimumSalary()
  * @method Job getMaximumSalary()
- * @method Job setId($value)
+ * @method Job setSourceId($value)
  * @method Job setTitle($value)
  * @method Job setDescription($value)
  * @method Job setSource($value)
@@ -150,7 +150,14 @@ class Job extends JobPosting
         return $this;
     }
 
-    public function setOccupationalCategory($code, $title)
+    /**
+     * Sets occupationalCategory with code and title as input
+     *
+     * @param float $occupationalCategory
+     *
+     * @return $this
+     */
+    public function setOccupationalCategoryWithCodeAndTitle($code, $title)
     {
         if ($code && $title) {
             parent::setOccupationalCategory($code . ' - ' . $title);

--- a/src/Job.php
+++ b/src/Job.php
@@ -56,6 +56,20 @@ class Job extends JobPosting
     protected $sourceId;
 
     /**
+     * Javascript Action
+     *
+     * @var string
+     */
+    protected $javascriptAction;
+
+    /**
+     * Javascript Function
+     *
+     * @var string
+     */
+    protected $javascriptFunction;
+
+    /**
      * Job Query
      *
      * @var string
@@ -153,7 +167,7 @@ class Job extends JobPosting
     /**
      * Sets occupationalCategory with code and title as input
      *
-     * @param float $occupationalCategory
+     * @param string $occupationalCategory
      *
      * @return $this
      */

--- a/src/Job.php
+++ b/src/Job.php
@@ -199,6 +199,54 @@ class Job extends JobPosting
     }
 
     /**
+     * Sets javascriptAction.
+     *
+     * @param string $javascriptAction
+     *
+     * @return $this
+     */
+    public function setJavascriptAction($action)
+    {
+        $this->javascriptAction = $action;
+
+        return $this;
+    }
+
+    /**
+     * Get javascriptAction.
+     *
+     * @return string $javascriptAction
+     */
+    public function getJavascriptAction()
+    {
+        return $this->javascriptAction;
+    }
+
+    /**
+     * Sets javascriptFunction.
+     *
+     * @param string $javascriptFunction
+     *
+     * @return $this
+     */
+    public function setJavascriptFunction($function)
+    {
+        $this->javascriptFunction = $function;
+
+        return $this;
+    }
+
+    /**
+     * Get javascriptFunction.
+     *
+     * @return string $javascriptFunction
+     */
+    public function getJavascriptFunction()
+    {
+        return $this->javascriptFunction;
+    }
+
+    /**
      * Get street address
      *
      * @return string

--- a/src/Job.php
+++ b/src/Job.php
@@ -8,7 +8,6 @@ use JobBrander\Jobs\Client\Schema\Entity\Place;
 use JobBrander\Jobs\Client\Schema\Entity\PostalAddress;
 
 /**
- * @method Job addCodes($value)
  * @method Job getId()
  * @method Job getTitle()
  * @method Job getDescription()
@@ -23,7 +22,6 @@ use JobBrander\Jobs\Client\Schema\Entity\PostalAddress;
  * @method Job getEndDate()
  * @method Job getMinimumSalary()
  * @method Job getMaximumSalary()
- * @method Job getCodes()
  * @method Job setId($value)
  * @method Job setTitle($value)
  * @method Job setDescription($value)
@@ -38,7 +36,6 @@ use JobBrander\Jobs\Client\Schema\Entity\PostalAddress;
  * @method Job setCompany($value)
  * @method Job setLocation($value)
  * @method Job setIndustry($value)
- * @method Job setCodes($value)
  */
 class Job extends JobPosting
 {
@@ -122,13 +119,6 @@ class Job extends JobPosting
     protected $industry;
 
     /**
-     * Job Codes
-     *
-     * @var array
-     */
-    protected $codes = [];
-
-    /**
      * Create new job
      *
      * @param array $attributes
@@ -155,6 +145,15 @@ class Job extends JobPosting
             $this->setDatePosted($datePosted);
         } else {
             throw new InvalidFormatException;
+        }
+
+        return $this;
+    }
+
+    public function setOccupationalCategory($code, $title)
+    {
+        if ($code && $title) {
+            parent::setOccupationalCategory($code . ' - ' . $title);
         }
 
         return $this;

--- a/test/src/JobTest.php
+++ b/test/src/JobTest.php
@@ -384,6 +384,14 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->job->setDatePostedAsString($date);
     }
 
+    public function testSetOccupationalCategoryWithCodeAndTitle()
+    {
+        $code = rand(1, 20) . '-' . rand(1000, 9999);
+        $title = uniqid();
+        $this->job->setOccupationalCategoryWithCodeAndTitle($code, $title);
+        $this->assertEquals($code . ' - ' . $title, $this->job->getOccupationalCategory());
+    }
+
     public function testBenignTextValues()
     {
         $attributes = [

--- a/test/src/JobTest.php
+++ b/test/src/JobTest.php
@@ -35,8 +35,8 @@ class JobTest extends \PHPUnit_Framework_TestCase
             'title' => $title
         ]);
 
-        $this->assertEquals($sourceId, $job->sourceId);
-        $this->assertEquals($title, $job->title);
+        $this->assertEquals($sourceId, $job->getSourceId());
+        $this->assertEquals($title, $job->getTitle());
     }
 
     public function testItCanCheckIfExistingPropertyIsset()
@@ -258,22 +258,6 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->job->setIndustry($industry);
         $this->assertEquals($industry, $this->job->industry);
         $this->assertEquals($industry, $this->job->getIndustry());
-    }
-
-    public function testSetCodes()
-    {
-        $codes = [uniqid()];
-        $this->job->setCodes($codes);
-        $this->assertEquals($codes, $this->job->codes);
-        $this->assertEquals($codes, $this->job->getCodes());
-    }
-
-    public function testAddCodes()
-    {
-        $code = uniqid();
-        $this->job->addCodes($code);
-        $this->assertContains($code, $this->job->codes);
-        $this->assertContains($code, $this->job->getCodes());
     }
 
     public function testSetStreetAddress()

--- a/test/src/JobTest.php
+++ b/test/src/JobTest.php
@@ -110,6 +110,22 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($input, $this->job->getTitle());
     }
 
+    public function testSetJavascriptAction()
+    {
+        $input = 'onclick';
+        $this->job->setJavascriptAction($input);
+        $this->assertEquals($input, $this->job->javascriptAction);
+        $this->assertEquals($input, $this->job->getJavascriptAction());
+    }
+
+    public function testSetJavascriptFunction()
+    {
+        $input = 'doJob(' . uniqid() . ')';
+        $this->job->setJavascriptFunction($input);
+        $this->assertEquals($input, $this->job->javascriptFunction);
+        $this->assertEquals($input, $this->job->getJavascriptFunction());
+    }
+
     public function testSetDescription()
     {
         $input = 'Test job listing description';


### PR DESCRIPTION
Check changelog or see description of changes in issue #5. This gets rid of the codes attribute and replaces it with necessary attributes. I also got rid of codes and the functionality to add array attributes to the job object.

@stevenmaguire let me know what you think. 