### PR TITLE
Adding JSON-LD serialization support

### DIFF
--- a/src/Job.php
+++ b/src/Job.php
@@ -11,7 +11,6 @@ use JobBrander\Jobs\Client\Schema\Entity\PostalAddress;
 /**
  * @method string getAlternateName()
  * @method float getBaseSalary()
- * @method string getBenefits()
  * @method string getCity()
  * @method string getCompany()
  * @method string getCompanyDescription()
@@ -27,10 +26,11 @@ use JobBrander\Jobs\Client\Schema\Entity\PostalAddress;
  * @method string getEndDate()
  * @method string getExperienceRequirements()
  * @method Organization getHiringOrganization()
- * @method string getIncentives()
+ * @method string getIncentiveCompensation()
  * @method string getIndustry()
  * @method string getJavascriptAction()
  * @method string getJavascriptFunction()
+ * @method string getJobBenefits()
  * @method Place getJobLocation()
  * @method string getLocation()
  * @method string getOccupationalCategory()
@@ -54,10 +54,9 @@ use JobBrander\Jobs\Client\Schema\Entity\PostalAddress;
  * @method string getType()
  * @method string getUrl()
  * @method string getWorkHours()
- *
+ * @method array jsonSerialize()
  * @method Job setAlternateName($value)
  * @method Job setBaseSalary($value)
- * @method Job setBenefits($value)
  * @method Job setCity($value)
  * @method Job setCompany($value)
  * @method Job setCompanyDescription($value)
@@ -74,10 +73,11 @@ use JobBrander\Jobs\Client\Schema\Entity\PostalAddress;
  * @method Job setEndDate($value)
  * @method Job setExperienceRequirements($value)
  * @method Job setHiringOrganization($value)
- * @method Job setIncentives($value)
+ * @method Job getIncentiveCompensation($value)
  * @method Job setIndustry($value)
  * @method Job setJavascriptAction($action)
  * @method Job setJavascriptFunction($function)
+ * @method Job setJobBenefits($value)
  * @method Job setJobLocation($value)
  * @method Job setLocation($value)
  * @method Job setMaximumSalary($value)
@@ -102,10 +102,11 @@ use JobBrander\Jobs\Client\Schema\Entity\PostalAddress;
  * @method Job setType($value)
  * @method Job setUrl($value)
  * @method Job setWorkHours($value)
+ * @method string toJson()
  */
 class Job extends JobPosting implements JsonSerializable
 {
-    use AttributeTrait;
+    use AttributeTrait, JsonLinkedDataTrait;
 
     /**
      * Job Company
@@ -444,48 +445,7 @@ class Job extends JobPosting implements JsonSerializable
      */
     public function jsonSerialize()
     {
-        $location = $this->getOrCreateJobLocation();
-        $organization = $this->getOrCreateHiringOrganization();
-        $address = $this->getOrCreatePostalAddress($location);
-
-        return [
-            "@context" => "http://schema.org",
-            "@type" => "JobPosting",
-            "baseSalary" => $this->getBaseSalary(),
-            "benefits" => $this->getBenefits(),
-            "datePosted" => date("Y-m-d", $this->getDatePosted()),
-            "description" => $this->getDescription(),
-            "educationRequirements" => $this->getEducationRequirements(),
-            "employmentType" => $this->getEmploymentType(),
-            "experienceRequirements" => $this->getExperienceRequirements(),
-            "hiringOrganization" => [
-                "@type" => "Organization",
-                "address" => [
-                    "@type" => "PostalAddress",
-                    "addressLocality" => $address->getAddressLocality(),
-                    "addressRegion" => $address->getAddressRegion()
-                ],
-                "telephone" => $organization->getTelephone()
-            ],
-            "incentives" => $this->getIncentives(),
-            "industry" => $this->getIndustry(),
-            "jobLocation" => [
-                "@type" => "Place",
-                "address" => [
-                    "@type" => "PostalAddress",
-                    "addressLocality" => $address->getAddressLocality(),
-                    "addressRegion" => $address->getAddressRegion()
-                ]
-            ],
-            "occupationalCategory" => $this->getOccupationalCategory(),
-            "qualifications" => $this->getQualifications(),
-            "responsibilities" => $this->getResponsibilities(),
-            "salaryCurrency" => $this->getSalaryCurrency(),
-            "skills" => $this->getSkills(),
-            "specialCommitments" => $this->getSpecialCommitments(),
-            "title" => $this->getTitle(),
-            "workHours" => $this->getWorkHours()
-        ];
+        return $this->serialize();
     }
 
     // Setters

--- a/src/Job.php
+++ b/src/Job.php
@@ -1,6 +1,7 @@
 <?php namespace JobBrander\Jobs\Client;
 
 use \DateTime;
+use \JsonSerializable;
 use JobBrander\Jobs\Client\Exceptions\InvalidFormatException;
 use JobBrander\Jobs\Client\Schema\Entity\JobPosting;
 use JobBrander\Jobs\Client\Schema\Entity\Organization;
@@ -8,36 +9,101 @@ use JobBrander\Jobs\Client\Schema\Entity\Place;
 use JobBrander\Jobs\Client\Schema\Entity\PostalAddress;
 
 /**
- * @method Job getSourceId()
- * @method Job getTitle()
- * @method Job getDescription()
- * @method Job getSource()
- * @method Job getUrl()
- * @method Job getQuery()
- * @method Job getType()
- * @method Job getCompany()
- * @method Job getLocation()
- * @method Job getIndustry()
- * @method Job getStartDate()
- * @method Job getEndDate()
- * @method Job getMinimumSalary()
- * @method Job getMaximumSalary()
- * @method Job setSourceId($value)
- * @method Job setTitle($value)
- * @method Job setDescription($value)
- * @method Job setSource($value)
- * @method Job setUrl($value)
- * @method Job setQuery($value)
- * @method Job setType($value)
- * @method Job setStartDate($value)
- * @method Job setEndDate($value)
- * @method Job setMinimumSalary($value)
- * @method Job setMaximumSalary($value)
+ * @method string getAlternateName()
+ * @method float getBaseSalary()
+ * @method string getBenefits()
+ * @method string getCity()
+ * @method string getCompany()
+ * @method string getCompanyDescription()
+ * @method string getCompanyEmail()
+ * @method string getCompanyLogo()
+ * @method string getCompanyName()
+ * @method string getCompanyUrl()
+ * @method string getCountry()
+ * @method \DateTime getDatePosted()
+ * @method string getDescription()
+ * @method string getEducationRequirements()
+ * @method string getEmploymentType()
+ * @method string getEndDate()
+ * @method string getExperienceRequirements()
+ * @method Organization getHiringOrganization()
+ * @method string getIncentives()
+ * @method string getIndustry()
+ * @method string getJavascriptAction()
+ * @method string getJavascriptFunction()
+ * @method Place getJobLocation()
+ * @method string getLocation()
+ * @method string getOccupationalCategory()
+ * @method string getName()
+ * @method string getMaximumSalary()
+ * @method string getMinimumSalary()
+ * @method string getPostalCode()
+ * @method string getQualifications()
+ * @method string getQuery()
+ * @method string getResponsibilities()
+ * @method string getSalaryCurrency()
+ * @method string getSkills()
+ * @method string getSource()
+ * @method string getSourceId()
+ * @method string getSpecialCommitments()
+ * @method string getStartDate()
+ * @method string getState()
+ * @method string getStreetAddress()
+ * @method string getTelephone()
+ * @method string getTitle()
+ * @method string getType()
+ * @method string getUrl()
+ * @method string getWorkHours()
+ *
+ * @method Job setAlternateName($value)
+ * @method Job setBaseSalary($value)
+ * @method Job setBenefits($value)
+ * @method Job setCity($value)
  * @method Job setCompany($value)
- * @method Job setLocation($value)
+ * @method Job setCompanyDescription($value)
+ * @method Job setCompanyEmail($value)
+ * @method Job setCompanyLogo($value)
+ * @method Job setCompanyName($value)
+ * @method Job setCompanyUrl($value)
+ * @method Job setCountry($value)
+ * @method Job setDatePosted($value)
+ * @method Job setDatePostedAsString($value)
+ * @method Job setDescription($value)
+ * @method Job setEducationRequirements($value)
+ * @method Job setEmploymentType($value)
+ * @method Job setEndDate($value)
+ * @method Job setExperienceRequirements($value)
+ * @method Job setHiringOrganization($value)
+ * @method Job setIncentives($value)
  * @method Job setIndustry($value)
+ * @method Job setJavascriptAction($action)
+ * @method Job setJavascriptFunction($function)
+ * @method Job setJobLocation($value)
+ * @method Job setLocation($value)
+ * @method Job setMaximumSalary($value)
+ * @method Job setMinimumSalary($value)
+ * @method Job setName($value)
+ * @method Job setOccupationalCategory($value)
+ * @method Job setOccupationalCategoryWithCodeAndTitle($code, $title)
+ * @method Job setPostalCode($value)
+ * @method Job setQualifications($value)
+ * @method Job setQuery($value)
+ * @method Job setResponsibilities($value)
+ * @method Job setSalaryCurrency($value)
+ * @method Job setSkills($value)
+ * @method Job setSource($value)
+ * @method Job setSourceId($value)
+ * @method Job setSpecialCommitments($value)
+ * @method Job setStartDate($value)
+ * @method Job setState($value)
+ * @method Job setStreetAddress($value)
+ * @method Job setTelephone($value)
+ * @method Job setTitle($value)
+ * @method Job setType($value)
+ * @method Job setUrl($value)
+ * @method Job setWorkHours($value)
  */
-class Job extends JobPosting
+class Job extends JobPosting implements JsonSerializable
 {
     use AttributeTrait;
 
@@ -827,5 +893,66 @@ class Job extends JobPosting
         }
 
         return null;
+    }
+
+    /**
+     * Allow class to be serialized with json_encode
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $location = $this->getOrCreateJobLocation();
+        $organization = $this->getOrCreateHiringOrganization();
+        $address = $this->getOrCreatePostalAddress($location);
+
+        return [
+            "@context" => "http://schema.org",
+            "@type" => "JobPosting",
+            "baseSalary" => $this->getBaseSalary(),
+            "benefits" => $this->getBenefits(),
+            "datePosted" => date("Y-m-d", $this->getDatePosted()),
+            "description" => $this->getDescription(),
+            "educationRequirements" => $this->getEducationRequirements(),
+            "employmentType" => $this->getEmploymentType(),
+            "experienceRequirements" => $this->getExperienceRequirements(),
+            "hiringOrganization" => [
+                "@type" => "Organization",
+                "address" => [
+                    "@type" => "PostalAddress",
+                    "addressLocality" => $address->getAddressLocality(),
+                    "addressRegion" => $address->getAddressRegion()
+                ],
+                "telephone" => $organization->getTelephone()
+            ],
+            "incentives" => $this->getIncentives(),
+            "industry" => $this->getIndustry(),
+            "jobLocation" => [
+                "@type" => "Place",
+                "address" => [
+                    "@type" => "PostalAddress",
+                    "addressLocality" => $address->getAddressLocality(),
+                    "addressRegion" => $address->getAddressRegion()
+                ]
+            ],
+            "occupationalCategory" => $this->getOccupationalCategory(),
+            "qualifications" => $this->getQualifications(),
+            "responsibilities" => $this->getResponsibilities(),
+            "salaryCurrency" => $this->getSalaryCurrency(),
+            "skills" => $this->getSkills(),
+            "specialCommitments" => $this->getSpecialCommitments(),
+            "title" => $this->getTitle(),
+            "workHours" => $this->getWorkHours()
+        ];
+    }
+
+    /**
+     * Serialize class as json
+     *
+     * @return string
+     */
+    public function toJson()
+    {
+        return json_encode($this);
     }
 }

--- a/src/Job.php
+++ b/src/Job.php
@@ -443,7 +443,7 @@ class Job extends JobPosting implements JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize($serializeSetting = null)
+    public function jsonSerialize($serializeSetting = self::SERIALIZE_STANDARD)
     {
         return $this->serialize($serializeSetting);
     }
@@ -772,7 +772,7 @@ class Job extends JobPosting implements JsonSerializable
      *
      * @return string
      */
-    public function toJson($serializeSetting = null)
+    public function toJson($serializeSetting = self::SERIALIZE_STANDARD)
     {
         return json_encode($this->jsonSerialize($serializeSetting));
     }

--- a/src/Job.php
+++ b/src/Job.php
@@ -108,6 +108,12 @@ class Job extends JobPosting implements JsonSerializable
 {
     use AttributeTrait, JsonLinkedDataTrait;
 
+    const SERIALIZE_STANDARD = "serialize-standard";
+
+    const SERIALIZE_STANDARD_LD = "serialize-standard-ld";
+
+    const SERIALIZE_CORE_SCHEMA_LD = "serialize-core-schema-ld";
+
     /**
      * Job Company
      *
@@ -441,13 +447,13 @@ class Job extends JobPosting implements JsonSerializable
     /**
      * Allow class to be serialized with json_encode
      *
-     * @param  boolean $useStrict
+     * @param  string $serializeSetting
      *
      * @return array
      */
-    public function jsonSerialize($useStrict = false)
+    public function jsonSerialize($serializeSetting = null)
     {
-        return $this->serialize($useStrict);
+        return $this->serialize($serializeSetting);
     }
 
     // Setters
@@ -770,13 +776,13 @@ class Job extends JobPosting implements JsonSerializable
     /**
      * Serialize class as json
      *
-     * @param  boolean $useStrict
+     * @param  string $serializeSetting
      *
      * @return string
      */
-    public function toJson($useStrict = false)
+    public function toJson($serializeSetting = null)
     {
-        return json_encode($this->jsonSerialize($useStrict));
+        return json_encode($this->jsonSerialize($serializeSetting));
     }
 
     // Private Methods

--- a/src/Job.php
+++ b/src/Job.php
@@ -51,7 +51,6 @@ use JobBrander\Jobs\Client\Schema\Entity\PostalAddress;
  * @method string getStreetAddress()
  * @method string getTelephone()
  * @method string getTitle()
- * @method string getType()
  * @method string getUrl()
  * @method string getWorkHours()
  * @method array jsonSerialize()
@@ -427,16 +426,6 @@ class Job extends JobPosting implements JsonSerializable
     }
 
     /**
-     * Gets type.
-     *
-     * @return string
-     */
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    /**
      * Allow class to be serialized with json_encode
      *
      * @param  string $serializeSetting
@@ -749,20 +738,6 @@ class Job extends JobPosting implements JsonSerializable
 
         return $this->setHiringOrganization($organization)
             ->setJobLocation($location);
-    }
-
-    /**
-     * Sets type.
-     *
-     * @param string $type
-     *
-     * @return $this
-     */
-    public function setType($type)
-    {
-        $this->type = $type;
-
-        return $this;
     }
 
     /**

--- a/src/Job.php
+++ b/src/Job.php
@@ -709,8 +709,12 @@ class Job extends JobPosting
      *
      * @return Organization
      */
-    public function getHiringOrganization()
+    public function getHiringOrganization($parent = false)
     {
+        if ($parent) {
+            return parent::getHiringOrganization();
+        }
+
         return $this->getOrCreateHiringOrganization();
     }
 
@@ -719,8 +723,12 @@ class Job extends JobPosting
      *
      * @return Place
      */
-    public function getJobLocation()
+    public function getJobLocation($parent = false)
     {
+        if ($parent) {
+            return parent::getJobLocation();
+        }
+
         return $this->getOrCreateJobLocation();
     }
 
@@ -731,7 +739,7 @@ class Job extends JobPosting
      */
     private function getOrCreateJobLocation()
     {
-        $location = parent::getJobLocation();
+        $location = $this->getJobLocation(true);
 
         if (!$location) {
             $location = new Place;
@@ -765,7 +773,7 @@ class Job extends JobPosting
      */
     private function getOrCreateHiringOrganization()
     {
-        $company = parent::getHiringOrganization();
+        $company = $this->getHiringOrganization(true);
 
         if (!$company) {
             $company = new Organization;

--- a/src/Job.php
+++ b/src/Job.php
@@ -441,11 +441,13 @@ class Job extends JobPosting implements JsonSerializable
     /**
      * Allow class to be serialized with json_encode
      *
+     * @param  boolean $useStrict
+     *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize($useStrict = false)
     {
-        return $this->serialize();
+        return $this->serialize($useStrict);
     }
 
     // Setters
@@ -768,11 +770,13 @@ class Job extends JobPosting implements JsonSerializable
     /**
      * Serialize class as json
      *
+     * @param  boolean $useStrict
+     *
      * @return string
      */
-    public function toJson()
+    public function toJson($useStrict = false)
     {
-        return json_encode($this);
+        return json_encode($this->jsonSerialize($useStrict));
     }
 
     // Private Methods

--- a/src/JsonLinkedDataTrait.php
+++ b/src/JsonLinkedDataTrait.php
@@ -5,15 +5,23 @@ trait JsonLinkedDataTrait
     /**
      * Serialize object as array
      *
-     * @param  boolean  $useStrict
+     * @param  string  $serializeSetting
      *
      * @return array
      */
-    protected function serialize($useStrict = false)
+    protected function serialize($serializeSetting = self::SERIALIZE_STANDARD)
     {
-        $array = ["@context" => "http://schema.org", "@type" => "JobPosting"];
+        $array = [];
 
-        $serializedArray = $this->createSerializedArrayFromObject($this);
+        if ($this->settingIsLinkedData($serializeSetting)) {
+            $array["@context"] = "http://schema.org";
+            $array["@type"] = "JobPosting";
+        }
+
+        $serializedArray = $this->createSerializedArrayFromObject(
+            $this,
+            $serializeSetting
+        );
 
         $array = array_merge($serializedArray, $array);
 
@@ -26,33 +34,67 @@ trait JsonLinkedDataTrait
      * Create serialized array of given object, including recursion
      *
      * @param  object $object
+     * @param  string $serializeSetting
      *
      * @return array
      */
-    private function createSerializedArrayFromObject($object)
+    private function createSerializedArrayFromObject($object, $serializeSetting)
     {
         $ref = new \ReflectionClass($object);
         $properties = $ref->getProperties();
 
-        $array = [
-            "@type" => $ref->getShortName(),
-        ];
+        $array = [];
+
+        if ($this->settingIsLinkedData($serializeSetting)) {
+            $array["@type"] = $ref->getShortName();
+        }
 
         foreach ($properties as $property) {
             $property->setAccessible(true);
             $name = $property->getName();
             $value = $property->getValue($object);
-            if (!is_object($value)) {
-                $array[$name] = $value;
-            } else {
-                if ($value instanceof \DateTime) {
-                    $array[$name] = date_format($value, 'Y-m-d');
+            if ($property->class != Job::class || !$this->settingIsCoreSchema($serializeSetting)) {
+
+                if (!is_object($value)) {
+                    $array[$name] = $value;
                 } else {
-                    $array[$name] = $this->createSerializedArrayFromObject($value);
+                    if ($value instanceof \DateTime) {
+                        $array[$name] = date_format($value, 'Y-m-d');
+                    } else {
+                        $array[$name] = $this->createSerializedArrayFromObject(
+                            $value,
+                            $serializeSetting
+                        );
+                    }
                 }
+
             }
         }
 
         return $array;
+    }
+
+    /**
+     * Check if setting indicates if only core schema should be included
+     *
+     * @param  string $setting
+     *
+     * @return boolean
+     */
+    private function settingIsCoreSchema($setting)
+    {
+        return in_array($setting, [self::SERIALIZE_CORE_SCHEMA_LD]);
+    }
+
+    /**
+     * Check if setting indicates if Linked Data support should be provided
+     *
+     * @param  string $setting
+     *
+     * @return boolean
+     */
+    private function settingIsLinkedData($setting)
+    {
+        return in_array($setting, [self::SERIALIZE_STANDARD_LD, self::SERIALIZE_CORE_SCHEMA_LD]);
     }
 }

--- a/src/JsonLinkedDataTrait.php
+++ b/src/JsonLinkedDataTrait.php
@@ -53,7 +53,7 @@ trait JsonLinkedDataTrait
             $property->setAccessible(true);
             $name = $property->getName();
             $value = $property->getValue($object);
-            if ($property->class != Job::class || !$this->settingIsCoreSchema($serializeSetting)) {
+            if ($property->class != 'JobBrander\Jobs\Client\Job' || !$this->settingIsCoreSchema($serializeSetting)) {
                 if (!is_object($value)) {
                     $array[$name] = $value;
                 } else {

--- a/src/JsonLinkedDataTrait.php
+++ b/src/JsonLinkedDataTrait.php
@@ -1,0 +1,58 @@
+<?php namespace JobBrander\Jobs\Client;
+
+trait JsonLinkedDataTrait
+{
+    /**
+     * Serialize object as array
+     *
+     * @param  boolean  $useStrict
+     *
+     * @return array
+     */
+    protected function serialize($useStrict = false)
+    {
+        $array = ["@context" => "http://schema.org", "@type" => "JobPosting"];
+
+        $serializedArray = $this->createSerializedArrayFromObject($this);
+
+        $array = array_merge($serializedArray, $array);
+
+        ksort($array);
+
+        return $array;
+    }
+
+    /**
+     * Create serialized array of given object, including recursion
+     *
+     * @param  object $object
+     *
+     * @return array
+     */
+    private function createSerializedArrayFromObject($object)
+    {
+        $ref = new \ReflectionClass($object);
+        $properties = $ref->getProperties();
+
+        $array = [
+            "@type" => $ref->getShortName(),
+        ];
+
+        foreach ($properties as $property) {
+            $property->setAccessible(true);
+            $name = $property->getName();
+            $value = $property->getValue($object);
+            if (!is_object($value)) {
+                $array[$name] = $value;
+            } else {
+                if ($value instanceof \DateTime) {
+                    $array[$name] = date_format($value, 'Y-m-d');
+                } else {
+                    $array[$name] = $this->createSerializedArrayFromObject($value);
+                }
+            }
+        }
+
+        return $array;
+    }
+}

--- a/src/JsonLinkedDataTrait.php
+++ b/src/JsonLinkedDataTrait.php
@@ -54,7 +54,6 @@ trait JsonLinkedDataTrait
             $name = $property->getName();
             $value = $property->getValue($object);
             if ($property->class != Job::class || !$this->settingIsCoreSchema($serializeSetting)) {
-
                 if (!is_object($value)) {
                     $array[$name] = $value;
                 } else {
@@ -67,7 +66,6 @@ trait JsonLinkedDataTrait
                         );
                     }
                 }
-
             }
         }
 

--- a/test/src/JobTest.php
+++ b/test/src/JobTest.php
@@ -521,7 +521,6 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->job->setStreetAddress($poBox);
         $this->job->setTelephone($value);
         $this->job->setTitle($value);
-        $this->job->setType($value);
         $this->job->setUrl($value);
         $this->job->setWorkHours($value);
 
@@ -641,7 +640,6 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->job->setSpecialCommitments($special);
         $this->job->setStartDate($date);
         $this->job->setTitle($title);
-        $this->job->setType($type);
         $this->job->setUrl($url);
         $this->job->setWorkHours($work_hours);
 
@@ -675,7 +673,6 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($special, $toObj->specialCommitments);
         $this->assertEquals($date->format('Y-m-d'), $toObj->startDate);
         $this->assertEquals($title, $toObj->title);
-        $this->assertEquals($type, $toObj->type);
         $this->assertEquals($url, $toObj->url);
         $this->assertEquals($work_hours, $toObj->workHours);
     }

--- a/test/src/JobTest.php
+++ b/test/src/JobTest.php
@@ -434,10 +434,11 @@ class JobTest extends \PHPUnit_Framework_TestCase
     public function testItCanBeSerializedAsJson()
     {
         $value = uniqid();
+        $date = new \DateTime();
+        $poBox = 'PO Box '.$value;
 
         $this->job->setAlternateName($value);
         $this->job->setBaseSalary($value);
-        $this->job->setBenefits($value);
         $this->job->setCity($value);
         $this->job->setCompany($value);
         $this->job->setCompanyDescription($value);
@@ -446,19 +447,17 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->job->setCompanyName($value);
         $this->job->setCompanyUrl($value);
         $this->job->setCountry($value);
-        //$this->job->setDatePosted($value);
-        //$this->job->setDatePostedAsString($value);
+        $this->job->setDatePosted($date);
         $this->job->setDescription($value);
         $this->job->setEducationRequirements($value);
         $this->job->setEmploymentType($value);
         $this->job->setEndDate($value);
         $this->job->setExperienceRequirements($value);
-        //$this->job->setHiringOrganization($value);
-        $this->job->setIncentives($value);
+        $this->job->setIncentiveCompensation($value);
         $this->job->setIndustry($value);
         $this->job->setJavascriptAction($value);
         $this->job->setJavascriptFunction($value);
-        //$this->job->setJobLocation($value);
+        $this->job->setJobBenefits($value);
         $this->job->setLocation($value);
         $this->job->setMaximumSalary($value);
         $this->job->setMinimumSalary($value);
@@ -476,7 +475,7 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->job->setSpecialCommitments($value);
         $this->job->setStartDate($value);
         $this->job->setState($value);
-        $this->job->setStreetAddress($value);
+        $this->job->setStreetAddress($poBox);
         $this->job->setTelephone($value);
         $this->job->setTitle($value);
         $this->job->setType($value);
@@ -487,7 +486,5 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $toJson = $this->job->toJson();
 
         $this->assertEquals($jsonEncode, $toJson);
-
-        print_r($jsonEncode);
     }
 }

--- a/test/src/JobTest.php
+++ b/test/src/JobTest.php
@@ -425,17 +425,26 @@ class JobTest extends \PHPUnit_Framework_TestCase
 
     public function testItCanJsonEncode()
     {
-        $job = $this->fillJobWithData();
+        $attributes = $this->getJobAttributes();
+
+        $job = new Job($attributes);
+        $job->setCompanyName($attributes['company']);
 
         $jsonEncode = json_encode($job);
         $toJson = $job->toJson();
 
         $this->assertEquals($jsonEncode, $toJson);
+
+        foreach ($attributes as $key => $value) {
+            $this->assertEquals($value, $job->{$key});
+        }
+
     }
 
     public function testItCanSerializeWithAllPropertiesByDefault()
     {
-        $job = $this->fillJobWithData();
+        $attributes = $this->getJobAttributes();
+        $job = new Job($attributes);
         $ref = new \ReflectionClass($job);
         $properties = $ref->getProperties();
 
@@ -448,7 +457,8 @@ class JobTest extends \PHPUnit_Framework_TestCase
 
     public function testItCanSerializeWithAllPropertiesAndLinkedDataContexts()
     {
-        $job = $this->fillJobWithData();
+        $attributes = $this->getJobAttributes();
+        $job = new Job($attributes);
         $ref = new \ReflectionClass($job);
         $properties = $ref->getProperties();
 
@@ -461,7 +471,8 @@ class JobTest extends \PHPUnit_Framework_TestCase
 
     public function testItCanSerializeWithCorePropertiesAndLinkedDataContexts()
     {
-        $job = $this->fillJobWithData();
+        $attributes = $this->getJobAttributes();
+        $job = new Job($attributes);
         $ref = new \ReflectionClass($job);
         $properties = array_filter($ref->getProperties(), function ($property) {
             return $property->class != 'JobBrander\Jobs\Client\Job';
@@ -474,206 +485,41 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals((count($properties) + 2), count($json));
     }
 
-    private function fillJobWithData()
+    private function getJobAttributes()
     {
-        $value = uniqid();
-        $date = new \DateTime();
-        $poBox = 'PO Box '.$value;
-
-        $this->job->setAlternateName($value);
-        $this->job->setBaseSalary($value);
-        $this->job->setCity($value);
-        $this->job->setCompany($value);
-        $this->job->setCompanyDescription($value);
-        $this->job->setCompanyEmail($value);
-        $this->job->setCompanyLogo($value);
-        $this->job->setCompanyName($value);
-        $this->job->setCompanyUrl($value);
-        $this->job->setCountry($value);
-        $this->job->setDatePosted($date);
-        $this->job->setDescription($value);
-        $this->job->setEducationRequirements($value);
-        $this->job->setEmploymentType($value);
-        $this->job->setEndDate($value);
-        $this->job->setExperienceRequirements($value);
-        $this->job->setIncentiveCompensation($value);
-        $this->job->setIndustry($value);
-        $this->job->setJavascriptAction($value);
-        $this->job->setJavascriptFunction($value);
-        $this->job->setJobBenefits($value);
-        $this->job->setLocation($value);
-        $this->job->setMaximumSalary($value);
-        $this->job->setMinimumSalary($value);
-        $this->job->setName($value);
-        $this->job->setOccupationalCategory($value);
-        $this->job->setOccupationalCategoryWithCodeAndTitle($value, $value);
-        $this->job->setPostalCode($value);
-        $this->job->setQualifications($value);
-        $this->job->setQuery($value);
-        $this->job->setResponsibilities($value);
-        $this->job->setSalaryCurrency($value);
-        $this->job->setSkills($value);
-        $this->job->setSource($value);
-        $this->job->setSourceId($value);
-        $this->job->setSpecialCommitments($value);
-        $this->job->setStartDate($value);
-        $this->job->setState($value);
-        $this->job->setStreetAddress($poBox);
-        $this->job->setTelephone($value);
-        $this->job->setTitle($value);
-        $this->job->setUrl($value);
-        $this->job->setWorkHours($value);
-
-        return $this->job;
-    }
-
-    public function testItSerializesCompanyData()
-    {
-        $name = uniqid();
-        $description = uniqid();
-        $email = uniqid();
-        $logo = uniqid();
-        $url = uniqid();
-
-        $this->job->setCompany($name);
-        $this->job->setCompanyDescription($description);
-        $this->job->setCompanyEmail($email);
-        $this->job->setCompanyLogo($logo);
-        $this->job->setCompanyName($name);
-        $this->job->setCompanyUrl($url);
-
-        $toJson = $this->job->toJson();
-        $toObj = json_decode($toJson);
-
-        $this->assertEquals($name, $toObj->company);
-        $this->assertEquals($description, $toObj->hiringOrganization->description);
-        $this->assertEquals($email, $toObj->hiringOrganization->email);
-        $this->assertEquals($logo, $toObj->hiringOrganization->logo);
-        $this->assertEquals($name, $toObj->hiringOrganization->name);
-        $this->assertEquals($url, $toObj->hiringOrganization->url);
-    }
-
-    public function testItSerializesLocationData()
-    {
-        $city = uniqid();
-        $country = uniqid();
-        $location = uniqid();
-        $postal_code = uniqid();
-        $state = uniqid();
-        $address = uniqid();
-        $telephone = uniqid();
-
-        $this->job->setCity($city);
-        $this->job->setCountry($country);
-        $this->job->setLocation($location);
-        $this->job->setPostalCode($postal_code);
-        $this->job->setState($state);
-        $this->job->setStreetAddress($address);
-        $this->job->setTelephone($telephone);
-
-        $toJson = $this->job->toJson();
-        $toObj = json_decode($toJson);
-
-        $this->assertEquals($location, $toObj->location);
-        $this->assertEquals($city, $toObj->jobLocation->address->addressLocality);
-        $this->assertEquals($country, $toObj->jobLocation->address->addressCountry);
-        $this->assertEquals($postal_code, $toObj->jobLocation->address->postalCode);
-        $this->assertEquals($state, $toObj->jobLocation->address->addressRegion);
-        $this->assertEquals($address, $toObj->jobLocation->address->streetAddress);
-        $this->assertEquals($telephone, $toObj->jobLocation->telephone);
-    }
-
-    public function testItSerializesJobData()
-    {
-        $alt_name = uniqid();
-        $base_salary = rand(10, 1000);
-        $date = new \DateTime();
-        $description = uniqid();
-        $education = uniqid();
-        $employment_type = uniqid();
-        $experience = uniqid();
-        $incentive_comp = uniqid();
-        $industry = uniqid();
-        $js_action = uniqid();
-        $js_function = uniqid();
-        $job_benefits = uniqid();
-        $max_salary = uniqid();
-        $name = uniqid();
-        $occupational_cat = uniqid();
-        $qualifications = uniqid();
-        $query = uniqid();
-        $responsibilities = uniqid();
-        $salary_currency = uniqid();
-        $skills = uniqid();
-        $source = uniqid();
-        $sourceId = uniqid();
-        $special = uniqid();
-        $title = uniqid();
-        $type = uniqid();
-        $url = uniqid();
-        $work_hours = uniqid();
-
-        $this->job->setAlternateName($alt_name);
-        $this->job->setBaseSalary($base_salary);
-        $this->job->setDatePosted($date);
-        $this->job->setDescription($description);
-        $this->job->setEducationRequirements($education);
-        $this->job->setEmploymentType($employment_type);
-        $this->job->setEndDate($date);
-        $this->job->setExperienceRequirements($experience);
-        $this->job->setIncentiveCompensation($incentive_comp);
-        $this->job->setIndustry($industry);
-        $this->job->setJavascriptAction($js_action);
-        $this->job->setJavascriptFunction($js_function);
-        $this->job->setJobBenefits($job_benefits);
-        $this->job->setMaximumSalary($max_salary);
-        $this->job->setMinimumSalary($base_salary);
-        $this->job->setName($name);
-        $this->job->setOccupationalCategory($occupational_cat);
-        $this->job->setQualifications($qualifications);
-        $this->job->setQuery($query);
-        $this->job->setResponsibilities($responsibilities);
-        $this->job->setSalaryCurrency($salary_currency);
-        $this->job->setSkills($skills);
-        $this->job->setSource($source);
-        $this->job->setSourceId($sourceId);
-        $this->job->setSpecialCommitments($special);
-        $this->job->setStartDate($date);
-        $this->job->setTitle($title);
-        $this->job->setUrl($url);
-        $this->job->setWorkHours($work_hours);
-
-        $toJson = $this->job->toJson();
-        $toObj = json_decode($toJson);
-
-        $this->assertEquals($alt_name, $toObj->alternateName);
-        $this->assertEquals($base_salary, $toObj->baseSalary);
-        $this->assertEquals($date->format('Y-m-d'), $toObj->datePosted);
-        $this->assertEquals($description, $toObj->description);
-        $this->assertEquals($education, $toObj->educationRequirements);
-        $this->assertEquals($employment_type, $toObj->employmentType);
-        $this->assertEquals($date->format('Y-m-d'), $toObj->endDate);
-        $this->assertEquals($experience, $toObj->experienceRequirements);
-        $this->assertEquals($incentive_comp, $toObj->incentiveCompensation);
-        $this->assertEquals($industry, $toObj->industry);
-        $this->assertEquals($js_action, $toObj->javascriptAction);
-        $this->assertEquals($js_function, $toObj->javascriptFunction);
-        $this->assertEquals($job_benefits, $toObj->jobBenefits);
-        $this->assertEquals($max_salary, $toObj->maximumSalary);
-        $this->assertEquals($base_salary, $toObj->minimumSalary);
-        $this->assertEquals($name, $toObj->name);
-        $this->assertEquals($occupational_cat, $toObj->occupationalCategory);
-        $this->assertEquals($qualifications, $toObj->qualifications);
-        $this->assertEquals($query, $toObj->query);
-        $this->assertEquals($responsibilities, $toObj->responsibilities);
-        $this->assertEquals($salary_currency, $toObj->salaryCurrency);
-        $this->assertEquals($skills, $toObj->skills);
-        $this->assertEquals($source, $toObj->source);
-        $this->assertEquals($sourceId, $toObj->sourceId);
-        $this->assertEquals($special, $toObj->specialCommitments);
-        $this->assertEquals($date->format('Y-m-d'), $toObj->startDate);
-        $this->assertEquals($title, $toObj->title);
-        $this->assertEquals($url, $toObj->url);
-        $this->assertEquals($work_hours, $toObj->workHours);
+        $attributes = [
+            'alternateName' => uniqid(),
+            'baseSalary' => rand(10, 1000),
+            'datePosted' => new \DateTime(),
+            'description' => uniqid(),
+            'educationRequirements' => uniqid(),
+            'employmentType' => uniqid(),
+            'endDate' => uniqid(),
+            'experienceRequirements' => uniqid(),
+            'incentiveCompensation' => uniqid(),
+            'industry' => uniqid(),
+            'javascriptAction' => uniqid(),
+            'javascriptFunction' => uniqid(),
+            'jobBenefits' => uniqid(),
+            'maximumSalary' => uniqid(),
+            'minimumSalary' => uniqid(),
+            'name' => uniqid(),
+            'occupationalCategory' => uniqid(),
+            'qualifications' => uniqid(),
+            'query' => uniqid(),
+            'responsibilities' => uniqid(),
+            'salaryCurrency' => uniqid(),
+            'skills' => uniqid(),
+            'source' => uniqid(),
+            'sourceId' => uniqid(),
+            'specialCommitments' => uniqid(),
+            'startDate' => new \DateTime(),
+            'title' => uniqid(),
+            'url' => uniqid(),
+            'workHours' => uniqid(),
+            'company' => uniqid(),
+            'location' => uniqid(),
+        ];
+        return $attributes;
     }
 }

--- a/test/src/JobTest.php
+++ b/test/src/JobTest.php
@@ -464,7 +464,7 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $job = $this->fillJobWithData();
         $ref = new \ReflectionClass($job);
         $properties = array_filter($ref->getProperties(), function ($property) {
-            return $property->class != Job::class;
+            return $property->class != 'JobBrander\Jobs\Client\Job';
         });
 
         $toJson = $job->toJson(Job::SERIALIZE_CORE_SCHEMA_LD);

--- a/test/src/JobTest.php
+++ b/test/src/JobTest.php
@@ -431,4 +431,63 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->job->getCountry());
     }
 
+    public function testItCanBeSerializedAsJson()
+    {
+        $value = uniqid();
+
+        $this->job->setAlternateName($value);
+        $this->job->setBaseSalary($value);
+        $this->job->setBenefits($value);
+        $this->job->setCity($value);
+        $this->job->setCompany($value);
+        $this->job->setCompanyDescription($value);
+        $this->job->setCompanyEmail($value);
+        $this->job->setCompanyLogo($value);
+        $this->job->setCompanyName($value);
+        $this->job->setCompanyUrl($value);
+        $this->job->setCountry($value);
+        //$this->job->setDatePosted($value);
+        //$this->job->setDatePostedAsString($value);
+        $this->job->setDescription($value);
+        $this->job->setEducationRequirements($value);
+        $this->job->setEmploymentType($value);
+        $this->job->setEndDate($value);
+        $this->job->setExperienceRequirements($value);
+        //$this->job->setHiringOrganization($value);
+        $this->job->setIncentives($value);
+        $this->job->setIndustry($value);
+        $this->job->setJavascriptAction($value);
+        $this->job->setJavascriptFunction($value);
+        //$this->job->setJobLocation($value);
+        $this->job->setLocation($value);
+        $this->job->setMaximumSalary($value);
+        $this->job->setMinimumSalary($value);
+        $this->job->setName($value);
+        $this->job->setOccupationalCategory($value);
+        $this->job->setOccupationalCategoryWithCodeAndTitle($value, $value);
+        $this->job->setPostalCode($value);
+        $this->job->setQualifications($value);
+        $this->job->setQuery($value);
+        $this->job->setResponsibilities($value);
+        $this->job->setSalaryCurrency($value);
+        $this->job->setSkills($value);
+        $this->job->setSource($value);
+        $this->job->setSourceId($value);
+        $this->job->setSpecialCommitments($value);
+        $this->job->setStartDate($value);
+        $this->job->setState($value);
+        $this->job->setStreetAddress($value);
+        $this->job->setTelephone($value);
+        $this->job->setTitle($value);
+        $this->job->setType($value);
+        $this->job->setUrl($value);
+        $this->job->setWorkHours($value);
+
+        $jsonEncode = json_encode($this->job);
+        $toJson = $this->job->toJson();
+
+        $this->assertEquals($jsonEncode, $toJson);
+
+        print_r($jsonEncode);
+    }
 }


### PR DESCRIPTION
This solution provides support for the following, based on #19.

The default serialization of the Job object will omit all Linked Data context properties and will include all properties. The following two expressions will yield identical strings.

```php
$jsonEncode = json_encode($job);
$toJson = $job->toJson();
```

The `toJson` method can accept one of three constant values, attached to the Job object. The `Job::SERIALIZE_STANDARD_LD` constant will result in a JSON string that includes all `Job` properties and the Linked Data context properties.

```php
$toJson = $job->toJson(Job::SERIALIZE_STANDARD_LD);
```

The `Job::SERIALIZE_CORE_SCHEMA_LD` constant will result in a JSON string that includes only `JobPosting` properties and the Linked Data context properties.

```php
$toJson = $job->toJson(Job::SERIALIZE_CORE_SCHEMA_LD);
```